### PR TITLE
Optimize normalization regex

### DIFF
--- a/internal/normalize/benchmark_test.go
+++ b/internal/normalize/benchmark_test.go
@@ -1,0 +1,28 @@
+package normalize
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/TFMV/resolve/internal/config"
+)
+
+func BenchmarkNormalizeEntity(b *testing.B) {
+	cfg := &config.Config{}
+	cfg.Normalization.EnableLowercase = true
+	cfg.Normalization.EnableStopwords = true
+	cfg.Normalization.NameOptions = map[string]bool{"remove_legal_suffixes": true, "normalize_initials": true}
+	cfg.Normalization.AddressOptions = map[string]bool{"remove_apartment_numbers": true}
+	n := NewNormalizer(cfg)
+
+	base := map[string]string{"name": "Test Corp", "address": "123 Main St Apt 4", "zip": "12345-6789"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fields := make(map[string]string, len(base))
+		for k, v := range base {
+			fields[k] = v + strconv.Itoa(i)
+		}
+		n.NormalizeEntity(fields)
+	}
+}

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -1,0 +1,44 @@
+package normalize
+
+import (
+	"testing"
+
+	"github.com/TFMV/resolve/internal/config"
+)
+
+func newTestNormalizer() *Normalizer {
+	cfg := &config.Config{}
+	cfg.Normalization.EnableLowercase = true
+	cfg.Normalization.EnableStopwords = true
+	cfg.Normalization.NameOptions = map[string]bool{"remove_legal_suffixes": true, "normalize_initials": true}
+	cfg.Normalization.AddressOptions = map[string]bool{"remove_apartment_numbers": true}
+	cfg.Normalization.PhoneOptions = map[string]bool{"e164_format": true}
+	cfg.Normalization.EmailOptions = map[string]bool{"lowercase_domain": true}
+	return NewNormalizer(cfg)
+}
+
+func TestNormalizeText(t *testing.T) {
+	n := newTestNormalizer()
+	got := n.NormalizeText("  The quick  brown fox  ")
+	want := "quick brown fox"
+	if got != want {
+		t.Errorf("expected %q got %q", want, got)
+	}
+}
+
+func TestNormalizeName(t *testing.T) {
+	n := newTestNormalizer()
+	if got := n.NormalizeName("ACME INC."); got != "acme" {
+		t.Errorf("NormalizeName remove suffix: %q", got)
+	}
+	if got := n.NormalizeName("J. D. Salinger"); got != "j d salinger" {
+		t.Errorf("NormalizeName initials: %q", got)
+	}
+}
+
+func TestNormalizeZip(t *testing.T) {
+	n := newTestNormalizer()
+	if got := n.NormalizeZip("12345-6789"); got != "12345" {
+		t.Errorf("expected 12345 got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- reuse compiled regex objects in Normalizer
- add tests for normalization routines
- benchmark normalization performance

## Testing
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68531d8a637c832ea025d7476e2bbe7e